### PR TITLE
fluent-builder: improve inheritance handling

### DIFF
--- a/plugin/src/main/java/com/kscs/util/plugins/xjc/BuilderGenerator.java
+++ b/plugin/src/main/java/com/kscs/util/plugins/xjc/BuilderGenerator.java
@@ -212,7 +212,7 @@ class BuilderGenerator {
 		if (childBuilderOutline != null && !childBuilderOutline.getClassOutline().getImplClass().isAbstract()) {
 			final JClass builderWithMethodReturnType = childBuilderOutline.getBuilderClass().narrow(this.builderClass.type.wildcard());
 			addMethod = this.builderClass.raw.method(JMod.PUBLIC, builderWithMethodReturnType, PluginContext.ADD_METHOD_PREFIX + propertyName);
-			generateBuilderMethodJavadoc(addMethod, "add", fieldName, schemaAnnotation);
+			generateBuilderMethodJavadoc(addMethod, ADD_METHOD_PREFIX, fieldName, schemaAnnotation);
 		} else {
 			addMethod = null;
 		}

--- a/plugin/src/main/java/com/kscs/util/plugins/xjc/BuilderGenerator.java
+++ b/plugin/src/main/java/com/kscs/util/plugins/xjc/BuilderGenerator.java
@@ -478,10 +478,10 @@ class BuilderGenerator {
 			final BuilderOutline childBuilderOutline = getBuilderDeclaration(fieldType);
 			if (childBuilderOutline != null && !childBuilderOutline.getClassOutline().getImplClass().isAbstract()) {
 				final JClass builderFieldElementType = childBuilderOutline.getBuilderClass().narrow(this.builderClass.type.wildcard());
-				final JMethod addMethod = this.builderClass.raw.method(JMod.PUBLIC, builderFieldElementType, WITH_METHOD_PREFIX + superPropertyName);
-				generateBuilderMethodJavadoc(addMethod, WITH_METHOD_PREFIX, superPropertyOutline.getFieldName(), propertyOutline.getSchemaAnnotationText().orElse(null));
+				final JMethod withChildBuilderMethod = this.builderClass.raw.method(JMod.PUBLIC, builderFieldElementType, WITH_METHOD_PREFIX + superPropertyName);
+				generateBuilderMethodJavadoc(withChildBuilderMethod, WITH_METHOD_PREFIX, superPropertyOutline.getFieldName(), propertyOutline.getSchemaAnnotationText().orElse(null));
 				if (this.implement) {
-					addMethod.body()._return(JExpr.cast(builderFieldElementType, JExpr._super().invoke(addMethod)));
+					withChildBuilderMethod.body()._return(JExpr.cast(builderFieldElementType, JExpr._super().invoke(withChildBuilderMethod)));
 				}
 			}
 		}

--- a/plugin/src/main/java/com/kscs/util/plugins/xjc/BuilderGenerator.java
+++ b/plugin/src/main/java/com/kscs/util/plugins/xjc/BuilderGenerator.java
@@ -806,7 +806,7 @@ class BuilderGenerator {
 		if(referencedDefinedClass != null) {
 			return this.builderOutlines.get(referencedDefinedClass.fullName());
 		} else {
-			return getReferencedBuilderOutline(propertyOutline.getRawType());
+			return getBuilderDeclaration(propertyOutline.getRawType());
 		}
 	}
 

--- a/plugin/src/main/java/com/kscs/util/plugins/xjc/BuilderGenerator.java
+++ b/plugin/src/main/java/com/kscs/util/plugins/xjc/BuilderGenerator.java
@@ -106,7 +106,7 @@ class BuilderGenerator {
 		this.builderClass = new GenerifiedClass(builderOutline.getDefinedBuilderClass(), BuilderGenerator.PARENT_BUILDER_TYPE_PARAMETER_NAME);
 		this.resources = ResourceBundle.getBundle(BuilderGenerator.class.getName());
 		this.implement = !this.builderClass.raw.isInterface();
-		if (builderOutline.getClassOutline().getSuperClass() == null || !builderOutline.getClassOutline().getSuperClass().isLocal()) {
+		if (!isSuperClassBuildable(builderOutline.getClassOutline())) {
 			final JMethod endMethod = this.builderClass.raw.method(JMod.PUBLIC, this.builderClass.typeParam, this.settings.getEndMethodName());
 			if (this.implement) {
 				this.parentBuilderField = this.builderClass.raw.field(JMod.PROTECTED | JMod.FINAL, this.builderClass.typeParam, BuilderGenerator.PARENT_BUILDER_PARAM_NAME);
@@ -535,7 +535,7 @@ class BuilderGenerator {
 	}
 
 	JMethod generateCopyOfMethod(final TypeOutline paramType, final boolean partial) {
-		if (paramType.getSuperClass() != null && paramType.getSuperClass().isLocal()) {
+		if (isSuperClassBuildable(paramType)) {
 			generateCopyOfMethod(paramType.getSuperClass(), partial);
 		}
 		final JMethod copyOfMethod = this.definedClass.method(JMod.PUBLIC | JMod.STATIC, this.builderClass.raw.narrow(Void.class), this.pluginContext.buildCopyMethodName);
@@ -563,7 +563,7 @@ class BuilderGenerator {
 			copyBuilderMethod.body()._return(copyGenerator.generatePartialArgs(this.pluginContext._new((JClass)copyBuilderMethod.type()).arg(parentBuilderParam).arg(JExpr._this()).arg(JExpr.TRUE)));
 			copyBuilderConvenienceMethod.body()._return(copyConvenienceGenerator.generatePartialArgs(this.pluginContext.invoke(this.settings.getNewCopyBuilderMethodName()).arg(JExpr._null())));
 		}
-		if (this.typeOutline.getSuperClass() != null && this.typeOutline.getSuperClass().isLocal()) {
+		if (isSuperClassBuildable(this.typeOutline)) {
 			copyBuilderMethod.annotate(Override.class);
 			copyBuilderConvenienceMethod.annotate(Override.class);
 		}
@@ -571,7 +571,7 @@ class BuilderGenerator {
 	}
 
 	private JMethod generateConveniencePartialCopyMethod(final TypeOutline paramType, final JMethod partialCopyOfMethod, final String methodName, final JExpression propertyTreeUseArg) {
-		if (paramType.getSuperClass() != null && paramType.getSuperClass().isLocal()) {
+		if (isSuperClassBuildable(paramType)) {
 			generateConveniencePartialCopyMethod(paramType.getSuperClass(), partialCopyOfMethod, methodName, propertyTreeUseArg);
 		}
 		final JMethod conveniencePartialCopyMethod = this.definedClass.method(JMod.PUBLIC | JMod.STATIC, this.builderClass.raw.narrow(Void.class), methodName);
@@ -604,7 +604,7 @@ class BuilderGenerator {
 			final CopyGenerator cloneGenerator = this.pluginContext.createCopyGenerator(copyToMethod, partial);
 			final JBlock body = copyToMethod.body();
 			final JVar otherRef;
-			if (this.typeOutline.getSuperClass() != null && this.typeOutline.getSuperClass().isLocal()) {
+			if (isSuperClassBuildable(this.typeOutline)) {
 				body.add(cloneGenerator.generatePartialArgs(this.pluginContext.invoke(JExpr._super(), copyToMethod.name()).arg(otherParam)));
 			}
 			otherRef = otherParam;
@@ -620,14 +620,14 @@ class BuilderGenerator {
 		final JVar otherParam = constructor.param(JMod.FINAL, this.typeOutline.getImplClass(), BuilderGenerator.OTHER_PARAM_NAME);
 		final JVar copyParam = constructor.param(JMod.FINAL, this.pluginContext.codeModel.BOOLEAN, BuilderGenerator.COPY_FLAG_PARAM_NAME);
 		final CopyGenerator cloneGenerator = this.pluginContext.createCopyGenerator(constructor, partial);
-		if (this.typeOutline.getSuperClass() != null && this.typeOutline.getSuperClass().isLocal()) {
+		if (isSuperClassBuildable(this.typeOutline)) {
 			constructor.body().add(cloneGenerator.generatePartialArgs(this.pluginContext._super().arg(parentBuilderParam).arg(otherParam).arg(copyParam)));
 		} else {
 			constructor.body().assign(JExpr._this().ref(this.parentBuilderField), parentBuilderParam);
 		}
 		final JConditional ifNullStmt = constructor.body()._if(otherParam.ne(JExpr._null()));
 		final JBlock body;
-		if (!this.settings.isCopyAlways() && (this.typeOutline.getSuperClass() == null || !this.typeOutline.getSuperClass().isLocal())) {
+		if (!this.settings.isCopyAlways() && !isSuperClassBuildable(this.typeOutline)) {
 			final JConditional ifCopyStmt = ifNullStmt._then()._if(copyParam);
 			ifCopyStmt._else().assign(this.storedValueField, otherParam);
 			ifNullStmt._else().assign(this.storedValueField, JExpr._null());
@@ -702,7 +702,6 @@ class BuilderGenerator {
 	}
 
 	public void buildProperties() throws SAXException {
-		final TypeOutline superClass = this.typeOutline.getSuperClass();
 		final JMethod initMethod;
 		final JVar productParam;
 		final JBlock initBody;
@@ -726,9 +725,11 @@ class BuilderGenerator {
 				}
 			}
 		}
-		if (superClass != null && superClass.isLocal()) {
+		if (isSuperClassBuildable(this.typeOutline)) {
+			final TypeOutline superClass = this.typeOutline.getSuperClass();
 			BuilderOutline superClassBuilder = getBuilderDeclaration(superClass.getImplClass());
-			if (superClassBuilder == null) throw new RuntimeException("Cannot find builder class name " + this.settings.getBuilderClassName().getClassName() + " of: " + superClass.getImplClass());
+			if (superClassBuilder == null)
+				throw new RuntimeException("Cannot find builder class name " + this.settings.getBuilderClassName().getClassName() + " of: " + superClass.getImplClass());
 			generateExtendsClause(superClassBuilder);
 			if (this.implement) initBody._return(JExpr._super().invoke(initMethod).arg(productParam));
 			generateBuilderMemberOverrides(superClass);
@@ -888,7 +889,9 @@ class BuilderGenerator {
 		if (this.pluginContext.getClassOutline(type) == null && this.pluginContext.getEnumOutline(type) == null && type.isReference() && !type.isArray() && type.fullName().contains(".")) {
 			final Class<?> runtimeParentClass;
 			try {
-				runtimeParentClass = Class.forName(type.binaryName());
+				// The Context ClassLoader is used to allow for tests to include files from previous runs on the classpath.
+				// PluginRunTest#testGenerateNetex contains an example.
+				runtimeParentClass = Class.forName(type.binaryName(), true, Thread.currentThread().getContextClassLoader());
 			} catch (final ClassNotFoundException e) {
 				return null;
 			}
@@ -917,4 +920,11 @@ class BuilderGenerator {
 		return MessageFormat.format(this.resources.getString(resourceKey), args);
 	}
 
+	private boolean isSuperClassBuildable(TypeOutline classOutline) {
+		var superClass = classOutline.getSuperClass();
+		if (superClass == null) {
+			return false;
+		}
+		return superClass.isLocal() || getReferencedBuilderOutline(superClass.getImplClass()) != null;
+	}
 }

--- a/plugin/src/test/java/com/kscs/util/test/PluginRunTest.java
+++ b/plugin/src/test/java/com/kscs/util/test/PluginRunTest.java
@@ -24,6 +24,8 @@
 package com.kscs.util.test;
 
 import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -140,6 +142,36 @@ public class PluginRunTest {
 				inFile("siri.xsd"),
 				"-Xfluent-builder"
 		);
+	}
+
+	@Test
+	public void testGenerateNetex() throws Exception {
+		final var subDir = "netex";
+		final var episodeFile = generatedSourcesDir.resolve(subDir).resolve("siri.episode");
+		final var compiledCodeSubDir = compiledCodeDir.resolve(subDir);
+
+		generateAndCompile(subDir,
+				"-episode", episodeFile.toString(),
+				inFile("siri.xsd"),
+				"-Xfluent-builder"
+		);
+
+		ClassLoader previousClassLoader = Thread.currentThread().getContextClassLoader();
+		ClassLoader testClassLoader =
+				URLClassLoader.newInstance(new URL[]{compiledCodeSubDir.toUri().toURL()}, previousClassLoader);
+
+		try {
+			Thread.currentThread().setContextClassLoader(testClassLoader);
+
+			runPlugin(subDir,
+					"-b", episodeFile.toString(),
+					inFile("netex.xsd"),
+					"-Xfluent-builder"
+			);
+			compileTestCode(subDir);
+		} finally {
+			Thread.currentThread().setContextClassLoader(previousClassLoader);
+		}
 	}
 
 	@Test

--- a/plugin/src/test/java/com/kscs/util/test/PluginRunTest.java
+++ b/plugin/src/test/java/com/kscs/util/test/PluginRunTest.java
@@ -135,6 +135,14 @@ public class PluginRunTest {
 	}
 
 	@Test
+	public void testGenerateSiri() throws Exception {
+		generateAndCompile("siri",
+				inFile("siri.xsd"),
+				"-Xfluent-builder"
+		);
+	}
+
+	@Test
 	public void testGenerateAll() throws Exception {
 		generateAndCompile("all","-b", inFile("binding-config.xjb"),
 				"-b", inFile("binding-config-xhtml.xjb"),

--- a/plugin/src/test/resources/netex.xsd
+++ b/plugin/src/test/resources/netex.xsd
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.netex.org.uk/netex"
+            xmlns:siri="http://www.siri.org.uk/siri"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://www.netex.org.uk/netex"
+            elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.siri.org.uk/siri siri.xsd">
+
+    <xs:import namespace="http://www.siri.org.uk/siri"
+               schemaLocation="siri.xsd"/>
+
+    <xsd:element name="DataObjectSubscriptionRequest" type="DataObjectSubscriptionStructure" />
+
+    <xsd:complexType name="DataObjectSubscriptionStructure">
+        <xsd:complexContent>
+            <xsd:extension base="siri:AbstractSubscriptionStructure">
+                <xsd:sequence>
+                    <xsd:element name="DataObjectRequest"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+</xsd:schema>

--- a/plugin/src/test/resources/siri.xsd
+++ b/plugin/src/test/resources/siri.xsd
@@ -2,6 +2,17 @@
 <xsd:schema xmlns="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             targetNamespace="http://www.siri.org.uk/siri" elementFormDefault="qualified"
             attributeFormDefault="unqualified" version="2.1" id="siri_vehicleMonitoring_service">
+
+    <xsd:complexType name="AbstractSubscriptionStructure" abstract="true">
+        <xsd:sequence>
+            <xsd:element name="InitialTerminationTime" type="xsd:dateTime">
+                <xsd:annotation>
+                    <xsd:documentation>Requested end time for subscription.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+
     <xsd:complexType name="VehicleActivityStructure">
         <xsd:sequence>
             <xsd:element name="MonitoredVehicleJourney">

--- a/plugin/src/test/resources/siri.xsd
+++ b/plugin/src/test/resources/siri.xsd
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.siri.org.uk/siri" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://www.siri.org.uk/siri" elementFormDefault="qualified"
+            attributeFormDefault="unqualified" version="2.1" id="siri_vehicleMonitoring_service">
+    <xsd:complexType name="VehicleActivityStructure">
+        <xsd:sequence>
+            <xsd:element name="MonitoredVehicleJourney">
+                <xsd:complexType>
+                    <xsd:complexContent>
+                        <xsd:extension base="MonitoredVehicleJourneyStructure"/>
+                    </xsd:complexContent>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="MonitoredVehicleJourneyStructure">
+        <xsd:sequence>
+            <xsd:element name="TrainNumbers" minOccurs="0">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="TrainNumberRef" type="TrainNumberRefStructure" maxOccurs="unbounded">
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="TrainNumberRefStructure">
+        <xsd:annotation>
+            <xsd:documentation>Type for reference to a TRAIN NUMBER</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="TrainNumber"/>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:simpleType name="TrainNumber">
+        <xsd:annotation>
+            <xsd:documentation>Type for identifier of an TRAIN NUMBER</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:NMTOKEN"/>
+    </xsd:simpleType>
+</xsd:schema>


### PR DESCRIPTION
Thank you for your work @mklemm! While updating from an older version we found two corner-cases related to fluent-builder inheritance handling which this PR improves:

1. `with*()` methods were not generated for superclasses due to differing checks. This was corrected by using the same checks to determine if the methods should be generated. (6edaa7d, #79)

2. when extending classes from previous runs of `xjc` using episodes the `Builder` inner classes were not found. This was corrected by modifying the `isLocal()` checks to also look at existing classes. (c5159fa)

Failing tests are added for both cases (ad02367, a5d93ef) using extracts from the SIRI and NeTEx standards, which pass after the relevant commits.